### PR TITLE
Removed pipeline-scripts submodule

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -189,10 +189,10 @@ testWinUnstable:
     GIT_SUBMODULE_STRATEGY: "none"
   artifacts:
     paths:
-      - "build/unittests.xml"
+      - "unittests.xml"
     expire_in: 1 week
     reports:
-      junit: build/unittests.xml
+      junit: unittests.xml
 
 testLinux:
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -143,56 +143,70 @@ linuxBuildReleaseUnstable:
 
 
 # run tests using the binary built before
+.testWinTemplate:
+  tags: ["windows", "docker"]
+  extends: 
+    - .run-always
+  before_script:
+    - '& $env:GTLAB_UPDATE_TOOL up --confirm-command; $null'
+  script:
+    - $env:path = "$env:GTLAB_DEV_TOOLS\binDebug;$env:path"
+    - cd build
+    - .\GTlabLoggingTests.exe --gtest_output=xml:unittests.xml
+  artifacts:
+    paths:
+      - "build/unittests.xml"
+    expire_in: 1 week
+    reports:
+      junit: build/unittests.xml
+
+# run tests using the binary built before
 testWin:
   stage: test
+  image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/gtlabdev-1_7-win
   extends: 
-    - .winTestTemplate
-    - .run-always
-  needs: 
-    - windowsBuildDebug
-  dependencies: 
-    - windowsBuildDebug
-  variables:
-    DEVTOOLS: $DEVTOOLS_Win_Stable
+    - .testWinTemplate
+  needs: ["windowsBuildDebug"]
 
 testWinUnstable:
   stage: unstableTest
+  image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/gtlabdev-2_0-win
   extends:
-    - .winTestTemplate
+    - .testWinTemplate
+  needs: ["windowsBuildDebugUnstable"]
+
+.testLinuxTemplate:
+  tags: ["linux", "docker"]
+  extends: 
     - .run-always
-  needs: 
-    - windowsBuildDebugUnstable
-  dependencies: 
-    - windowsBuildDebugUnstable
+  before_script:
+    # update to latest dev tools
+    - '"$GTLAB_UPDATE_TOOL" up --confirm-command'
+  script:
+    - export LD_LIBRARY_PATH=`pwd`/install-linux-dbg/lib/logging
+    - ./build/GTlabLoggingTests --gtest_output=xml:unittests.xml
   variables:
-    DEVTOOLS: $DEVTOOLS_Win_Unstable  
+    GIT_SUBMODULE_STRATEGY: "none"
+  artifacts:
+    paths:
+      - "build/unittests.xml"
+    expire_in: 1 week
+    reports:
+      junit: build/unittests.xml
 
 testLinux:
   stage: test
   extends: 
-    - .linuxTestTemplate
-    - .run-always
-  needs: 
-    - linuxBuildDebug
-  script:
-    - export LD_LIBRARY_PATH=`pwd`/install-linux-dbg/lib/logging
-    - ./build/GTlabLoggingTests --gtest_output=xml:unittests.xml
-  variables:
-    DEVTOOLS: $DEVTOOLS_Linux_Stable    
+    - .testLinuxTemplate
+  image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/gtlabdev-1_7-buster
+  needs: ["linuxBuildDebug"]
 
 testLinuxUnstable:
   stage: unstableTest
-  variables:
-    DEVTOOLS: $DEVTOOLS_Linux_Unstable 
-    LINUX_QT_DIR: /opt/Qt/5.15.2/gcc_64
   extends: 
-    - .linuxTestTemplate
-    - .run-always
-  needs: 
-    - linuxBuildDebugUnstable
-  script:
-    - export LD_LIBRARY_PATH=`pwd`/install-linux-dbg/lib/logging
-    - ./build/GTlabLoggingTests --gtest_output=xml:unittests.xml
+    - .testLinuxTemplate
+  image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/gtlabdev-2_0-buster
+  needs: ["linuxBuildDebugUnstable"]
 
 .package:
   stage: package

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tests/pipeline-scripts"]
-	path = tests/pipeline-scripts
-	url = https://gitlab.dlr.de/at-twk/gitlab-pipeline-scripts.git

--- a/tests/unittests/test_types.cpp
+++ b/tests/unittests/test_types.cpp
@@ -76,8 +76,6 @@ print(const char* text, double num, Cap c)
         << std::setw(24) << std::fixed        << num << " |\n"
         << "| " << std::setw(8) << text << " | scientific | "
         << std::setw(24) << std::scientific   << num << " |\n"
-        << "| " << std::setw(8) << text << " | hexfloat   | "
-        << std::setw(24) << std::setprecision(3) << std::hexfloat << num << " |\n"
         << "| " << std::setw(8) << text << " | default    | "
         << std::setw(24) << std::defaultfloat << num << " |\n";
 
@@ -107,21 +105,14 @@ TEST_F(Types, iomanips)
 "|----------|------------|--------------------------|\n"
 "| 0.25     | fixed      | 0.250000                 |\n"
 "| 0.25     | scientific | 2.500000e-01             |\n"
-#ifdef _WIN32
-"| 0.25     | hexfloat   | 0x1.0000000000000p-2     |\n"
-#else
-"| 0.25     | hexfloat   | 0x1p-2                   |\n"
-#endif
 "| 0.25     | default    | 0.25                     |\n"
 "|----------|------------|--------------------------|\n"
 "| 0.01     | fixed      | 0.010000                 |\n"
 "| 0.01     | scientific | 1.000000e-02             |\n"
-"| 0.01     | hexfloat   | 0x1.47ae147ae147bp-7     |\n"
 "| 0.01     | default    | 0.01                     |\n"
 "|----------|------------|--------------------------|\n"
 "| 0.00001  | fixed      | 0.000010                 |\n"
 "| 0.00001  | scientific | 1.000000e-05             |\n"
-"| 0.00001  | hexfloat   | 0x1.4f8b588e368f1p-17    |\n"
 "| 0.00001  | default    | 1e-05                    |\n"
 "----------------------------------------------------");
     EXPECT_TRUE(log.contains(expected));


### PR DESCRIPTION
The pipeline script submodule was used from DLR's gitlab, which makes it a hassle to checkout gt-logging without an DLR account. I needed to tweak the CI to work without the pipeline script though a bit.

I also needed to remove the hexfloat tests as the results were very much platform dependent
and failed on MSVC 2017.

Closes #127 