### PR TITLE
Resolve "Add space/nospace and qoute/noqoute iomanips to alter stream flags on the fly"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added `(no)space` and `(no)quote` manipulators to alter flags of the stream on the fly. - #129
+
 ## [4.4.1] - 2023-11-21
 ### General changes
  - This is the first release as Open Source Software

--- a/src/gt_logstream.h
+++ b/src/gt_logstream.h
@@ -70,9 +70,16 @@ public:
     Stream& operator=(Stream const&) = delete;
     Stream& operator=(Stream&&) = default;
 
+    /// enables space flag, thus outputs a space after logging an element.
+    /// Will only affect the next message.
     inline Stream& space()   { m_flags |=  LogSpace; return *this; }
+    /// disables space flag, thus outputs no space after logging an element.
+    /// Will only affect the next message.
     inline Stream& nospace() { m_flags &= ~LogSpace; return *this; }
+    /// enables the quote flag, which adds quotes around the next string
+    /// type to log.
     inline Stream& quote()   { m_flags |=  LogQuote; return *this; }
+    /// disbales the quote flag, thus logging string type without decorations.
     inline Stream& noquote() { m_flags &= ~LogQuote; return *this; }
 
     Stream& medium() { return verbose(gt::log::Medium); }
@@ -228,7 +235,8 @@ private:
 
 // pair
 template <typename T, typename U>
-inline Stream& operator<<(Stream& s, std::pair<T, U> const& t)
+inline Stream&
+operator<<(Stream& s, std::pair<T, U> const& t)
 {
     if (s.mayLog())
     {
@@ -268,6 +276,18 @@ inline Stream& Stream::doLogIter(Iter a, Iter b,
     }
     return *this;
 };
+
+inline Stream& nospace(Stream& s) { return s.nospace(); }
+inline Stream& space(Stream& s) { return s.space(); }
+
+inline Stream& noquote(Stream& s) { return s.noquote(); }
+inline Stream& quote(Stream& s) { return s.quote(); }
+
+inline gt::log::Stream&
+operator<<(gt::log::Stream& s, gt::log::Stream&(*f)(gt::log::Stream&))
+{
+    return f(s);
+}
 
 } // namespace log
 

--- a/tests/unittests/test_loglevel.cpp
+++ b/tests/unittests/test_loglevel.cpp
@@ -20,8 +20,8 @@ struct LogLevel : public LogHelperTest
 
 };
 
-// member methods should be callable as well
-TEST_F(LogLevel, toString)
+/// convert levels to string and from string
+TEST_F(LogLevel, toStringFromString)
 {
     using namespace gt::log;
     testLevel(TraceLevel);
@@ -32,7 +32,7 @@ TEST_F(LogLevel, toString)
     testLevel(FatalLevel);
 }
 
-// member methods should be callable as well
+/// OffLevel should deactive logging of messages
 TEST_F(LogLevel, offLevel)
 {
     using namespace gt::log;

--- a/tests/unittests/test_logquote.cpp
+++ b/tests/unittests/test_logquote.cpp
@@ -12,14 +12,16 @@ class LogQuote : public LogHelperTest
 
 TEST_F(LogQuote, logQString)
 {
-    gtWarning() << "Hello" << QString{"World"};
-    EXPECT_TRUE(log.contains("Hello \"World\""));
+    gtWarning() << "Hello" << QString{"World"}
+                << gt::log::noquote << QString{"!"};
+    EXPECT_TRUE(log.contains("Hello \"World\" !"));
 }
 
 TEST_F(LogQuote, logQChar)
 {
-    gtWarning() << 'T' << QChar{'E'} << 'S' << QChar{'T'};
-    EXPECT_TRUE(log.contains("T \"E\" S \"T\""));
+    gtWarning() << 'T' << QChar{'E'} << 'S' << QChar{'T'}
+                << gt::log::noquote << QChar{'!'};
+    EXPECT_TRUE(log.contains("T \"E\" S \"T\" !"));
 }
 
 // member methods should be callable as well
@@ -27,4 +29,17 @@ TEST_F(LogQuote, callMemberMethod)
 {
     gtWarning().nospace() << 'T' << QChar{'E'} << 'S' << QLatin1String{"T"};
     EXPECT_TRUE(log.contains("T\"E\"S\"T\""));
+}
+
+TEST_F(LogQuote, iomanip)
+{
+    gtWarning() << 'T' << QChar{'E'} << 'S'
+                << gt::log::nospace // will not append a space for the next message
+                << QChar{'T'}
+                << gt::log::space // will append a space for the next message
+                << gt::log::noquote // disables quotations
+                << QString{"!"}
+                << gt::log::quote // enables quotations
+                << QString{":)"};
+    EXPECT_TRUE(log.contains("T \"E\" S \"T\"! \":)\""));
 }


### PR DESCRIPTION
Closes #129

Implement manipulators `gt::log::nospace`, `gt::log::space`, `gt::log::noquote`, and `gt::log::quote` to alter the flags for logging spaces after the next messages and to log quotes around string types for the next message.