### PR TITLE
Draft: Resolve "Allow to log a range defined by iterators"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added `(no)space` and `(no)quote` manipulators to alter flags of the stream on the fly. - #129
+- Added `range` function to log a range denoted by iterators. Can be used to log any custom container type as long as its value type can be logged. Can be used to customize how a range/container is logged by specifying a custom formatting. - #137
 
 ## [4.4.1] - 2023-11-21
 ### General changes

--- a/src/gt_logformatter.h
+++ b/src/gt_logformatter.h
@@ -87,7 +87,7 @@ formatImpl(size_t idx, Iter begin, Iter end, Arg const& arg, Args const&... args
     return formatImpl(idx + 1, begin, end, args...);
 }
 
-} // namespace details
+} // namespace detail
 
 /**
  * @brief Formats the argument list depending on the format string similar to

--- a/src/gt_logstream.h
+++ b/src/gt_logstream.h
@@ -284,10 +284,66 @@ inline Stream& space(Stream& s) { return s.space(); }
 inline Stream& noquote(Stream& s) { return s.noquote(); }
 inline Stream& quote(Stream& s) { return s.quote(); }
 
-inline gt::log::Stream&
-operator<<(gt::log::Stream& s, gt::log::Stream&(*f)(gt::log::Stream&))
+inline Stream&
+operator<<(Stream& s, Stream&(*f)(Stream&))
 {
     return f(s);
+}
+
+namespace detail
+{
+
+template <typename Iter>
+struct RangeType
+{
+    Iter begin = {}, end = {};
+    char const* pre = {}, *suf = {}, *sep{};
+};
+
+} // namespace detail
+
+/**
+ * @brief Allows to log a range of iterators.
+ * @param begin Begin iterator
+ * @param end End iterator
+ * @param pre Prefix for range
+ * @param suf Suffix for range
+ * @param sep Separator for range
+ * @return Helper object to log the range defined by the iterators
+ */
+template <typename Iter>
+inline detail::RangeType<Iter> range(Iter begin, Iter end,
+                                     char const* pre = "(",
+                                     char const* suf = ")",
+                                     char const* sep = ", ")
+{
+    return {begin, end, pre, suf, sep};
+}
+
+/**
+ * @brief Overlaod that calls `begin()` and `end()` on the range `r` to log
+ * the range.
+ * @param r Range object
+ * @param pre Prefix for range
+ * @param suf Suffix for range
+ * @param sep Separator for range
+ * @return Helper object to log the range `r`
+ */
+template <typename Range>
+inline auto range(Range const& r,
+                  char const* pre = "(",
+                  char const* suf = ")",
+                  char const* sep = ", ")
+{
+    return range(r.begin(), r.end(), pre, suf, sep);
+}
+
+/// operator to log range
+template <typename Iter>
+inline Stream&
+operator<<(Stream& s, detail::RangeType<Iter> r)
+{
+    return s.doLogIter(r.begin, r.end, r.pre, r.suf, r.sep);
 }
 
 } // namespace log

--- a/tests/unittests/test_types.cpp
+++ b/tests/unittests/test_types.cpp
@@ -390,3 +390,52 @@ TEST_F(Types, Strings)
     gtInfo() << s << qAsConst(s);
     EXPECT_TRUE(log.contains(s.c_str()));
 }
+
+TEST_F(Types, iterator_range)
+{
+    std::vector<int> vec{1, 2, 3, 4};
+
+    gtInfo() << gt::log::range(vec.begin(), vec.end());
+    EXPECT_TRUE(log.contains("(1, 2, 3, 4)"));
+
+    log.clear();
+    gtInfo() << gt::log::range(vec.begin(), vec.end(), "range: ", "", ";");
+    EXPECT_TRUE(log.contains("range: 1;2;3;4"));
+}
+
+TEST_F(Types, iterator_range_custom_type)
+{
+    class MyContainer
+    {
+    public:
+        auto begin() const { return data.begin(); }
+        auto end() const { return data.end(); }
+
+        void resize(size_t size) {
+            data.resize(size);
+            // make objects unique
+            int i = 0;
+            for (auto& entry : data) entry.i = i++;
+        }
+
+    private:
+        std::vector<MyStruct> data;
+    };
+
+    MyContainer con;
+    con.resize(10);
+
+    // log a subrange
+    gtInfo() << gt::log::range(con.begin() + 5, con.begin() + 5 + 2);
+    EXPECT_TRUE(log.contains("(MyStruct(5), MyStruct(6))"));
+
+    log.clear();
+    // empty range
+    gtInfo() << gt::log::range(con.end(), con.end(), "{", "}");
+    EXPECT_TRUE(log.contains("{}"));
+
+    log.clear();
+    // log whole range
+    gtInfo() << gt::log::range(con);
+    EXPECT_EQ(log.count("MyStruct"), 10);
+}

--- a/tests/unittests/test_types_qt.cpp
+++ b/tests/unittests/test_types_qt.cpp
@@ -285,3 +285,21 @@ TEST_F(TypesQt, QWidget)
                 log.contains("QObject(0x0)"));
 }
 
+TEST_F(TypesQt, iterator_range)
+{
+    QMap<QString, int> map;
+    map.insert("a", 11);
+    map.insert("b", 22);
+
+    // default iterators
+    gtInfo() << gt::log::range(map.begin(), map.end());
+    EXPECT_TRUE(log.contains("(11, 22)"));
+
+    log.clear();
+    // custom iterators
+    gtInfo() << gt::log::range(map.constKeyValueBegin(),
+                               map.constKeyValueEnd());
+    EXPECT_TRUE(log.contains(R"((("a", 11), ("b", 22)))") ||
+                log.contains(R"((("b", 22), ("a", 11)))"));
+}
+


### PR DESCRIPTION
closes #137 

The logging library can now be used to log any container type (as long as its value type can be logged) given a begin and end iterator with a custom formatting (prefix, suffix and custom separators) . Thus, subranges are also supported. 

Syntax:

```c++
std::vector<int> v{1, 2, 3, 4, 5};
gtDebug() << gt::log::range(v.begin(), v.end(), "{", "}", "-");
// Output: {1-2-3-4-5}
```