### PR TITLE
Fix compilation errors with Qt6

### DIFF
--- a/src/gt_logging/qt_bindings.h
+++ b/src/gt_logging/qt_bindings.h
@@ -12,6 +12,7 @@
 #include <QObject>
 #include <QVector>
 #include <QList>
+#include <QVariant>
 
 namespace gt
 {
@@ -115,9 +116,11 @@ inline Stream& operator<<(Stream& s, T const* t) { return detail::doLogQt(s, t);
 template <typename T, detail::if_not_base_of_qobject<T> = true>
 inline Stream& operator<<(Stream& s, T const* t) { return s << static_cast<void const*>(t); }
 
+#if QT_VERSION < 0x060000
 // template based operators: non QObject*
 template <typename T>
 inline Stream& operator<<(Stream& s, QVector<T> const& t) { return s.doLogIter(t.begin(), t.end()); }
+#endif
 
 // template based operators: non QObject*
 template <typename T>


### PR DESCRIPTION
Fixes
```
/home/martin/.conan2/p/b/qtfde2b8e065ec7/p/include/QtCore/qdebug.h:510:1: error: no type named ‘type’ in ‘struct std::enable_if<false, QDebug>’
  510 | operator<<(QDebug dbg, T value)
      | ^~~~~~~~
/home/martin/.conan2/p/b/gtlab81d999b55682f/p/include/logging/gt_logging/qt_bindings.h: In instantiation of ‘gt::log::Stream& gt::log::detail::doLogQt(gt::log::Stream&, const T&) [with T = QVariant]’:
/home/martin/.conan2/p/b/gtlab81d999b55682f/p/include/logging/gt_logging/qt_bindings.h:108:81:   required from here
  108 | inline Stream& operator<<(Stream& s, const QVariant& t) { return detail::doLogQt(s, t); }
      |                                                                  ~~~~~~~~~~~~~~~^~~~~~
/home/martin/.conan2/p/b/qtfde2b8e065ec7/p/include/QtCore/qdebug.h:522:15: note: candidate: ‘template<class T, class A, class B, class C, class D> QDebug operator<<(QDebug, T)’
  522 | inline QDebug operator<<(QDebug dbg, T value)
      |               ^~~~~~~~
/home/martin/.conan2/p/b/qtfde2b8e065ec7/p/include/QtCore/qdebug.h:522:15: note:   template argument deduction/substitution failed:
/home/martin/.conan2/p/b/qtfde2b8e065ec7/p/include/QtCore/qdebug.h:518:10: error: no type named ‘type’ in ‘struct std::enable_if<false, void>’
  518 |          typename A = typename std::enable_if<std::is_enum<T>::value, void>::type,
      |          ^~~~~~~~
/home/martin/.conan2/p/b/qtfde2b8e065ec7/p/include/QtCore/qdebug.h:556:15: note: candidate: ‘template<class T> QDebug operator<<(QDebug, const QFlags<T>&)’
  556 | inline QDebug operator<<(QDebug debug, const QFlags<T> &flags)
      |               ^~~~~~~~
/home/martin/.conan2/p/b/qtfde2b8e065ec7/p/include/QtCore/qdebug.h:556:15: note:   template argument deduction/substitution failed:
/home/martin/.conan2/p/b/gtlab81d999b55682f/p/include/logging/gt_logging/qt_bindings.h:92:11: note:   ‘const QVariant’ is not derived from ‘const QFlags<T>’
   92 |         d << t;
      |         ~~^~~~
/home/martin/.conan2/p/b/qtfde2b8e065ec7/p/include/QtCore/qdebug.h:563:15: note: candidate: ‘QDebug operator<<(QDebug, QKeyCombination)’
  563 | inline QDebug operator<<(QDebug debug, QKeyCombination combination)
      |               ^~~~~~~~
/home/martin/.conan2/p/b/qtfde2b8e065ec7/p/include/QtCore/qdebug.h:563:56: note:   no known conversion for argument 2 from ‘const QVariant’ to ‘QKeyCombination’
  563 | inline QDebug operator<<(QDebug debug, QKeyCombination combination)
      |                                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~
```

and 

```
/home/martin/.conan2/p/b/gtlab81d999b55682f/p/include/logging/gt_logging/qt_bindings.h:124:16: error: redefinition of ‘template<class T> gt::log::Stream& gt::log::operator<<(Stream&, const QList<T>&)’
  124 | inline Stream& operator<<(Stream& s, QList<T> const& t) { return s.doLogIter(t.begin(), t.end()); }
      |                ^~~~~~~~
/home/martin/.conan2/p/b/gtlab81d999b55682f/p/include/logging/gt_logging/qt_bindings.h:120:16: note: ‘template<class T> gt::log::Stream& gt::log::operator<<(Stream&, QVector<T>&)’ previously declared here
  120 | inline Stream& operator<<(Stream& s, QVector<T> const& t) { return s.doLogIter(t.begin(), t.end()); }
      |                ^~~~~~~~
```

`QVector` is just an alias for `QList` in Qt6.