### PR TITLE
Improved Qt6 support

### DIFF
--- a/src/gt_logging/qt_bindings.h
+++ b/src/gt_logging/qt_bindings.h
@@ -7,12 +7,15 @@
 #include "gt_logging.h"
 #include "gt_logging/stl_bindings.h"
 
-#include <QDebug>
 #include <QtGlobal>
 #include <QObject>
 #include <QVector>
 #include <QList>
 #include <QVariant>
+#include <QStringList>
+
+#include <QDebug>
+
 
 namespace gt
 {
@@ -129,7 +132,10 @@ inline Stream& operator<<(Stream& s, QList<T> const& t) { return s.doLogIter(t.b
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 // With Qt6, QStringList matches QList<QString> resulting in a different output
 // Hence, we need to provide a custom operator for QStringList
-inline Stream& operator<<(Stream& s, QStringList const& t) { return detail::doLogQt(s, t); }
+inline Stream& operator<<(Stream& s, QStringList const& t)
+{
+    return s << QStringLiteral("(%1)").arg(t.join(QStringLiteral(", ")));
+}
 #endif
 
 // check for ::operator<<(QDebug, T)

--- a/src/gt_logging/qt_bindings.h
+++ b/src/gt_logging/qt_bindings.h
@@ -126,6 +126,12 @@ inline Stream& operator<<(Stream& s, QVector<T> const& t) { return s.doLogIter(t
 template <typename T>
 inline Stream& operator<<(Stream& s, QList<T> const& t) { return s.doLogIter(t.begin(), t.end()); }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+// With Qt6, QStringList matches QList<QString> resulting in a different output
+// Hence, we need to provide a custom operator for QStringList
+inline Stream& operator<<(Stream& s, QStringList const& t) { return detail::doLogQt(s, t); }
+#endif
+
 // check for ::operator<<(QDebug, T)
 template<typename T,
          detail::if_not_integral_and_pointer<T> = true,

--- a/src/gt_logging/stl_bindings.h
+++ b/src/gt_logging/stl_bindings.h
@@ -14,5 +14,21 @@
 #include "gt_logging/set.h"
 #include "gt_logging/tuple.h"
 
+namespace gt
+{
+
+namespace log
+{
+
+// make std::string explicitly match, to avoid collision with qt types
+inline Stream& operator<<(Stream& s, std::string const& t)
+{
+    s.operator <<(t);
+    return s;
+}
+
+} // namespace log
+} // namespace gt
+
 
 #endif // GT_LOGGING_STL_BINDINGS_H

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -4,16 +4,16 @@
 cmake_minimum_required(VERSION 3.8)
 project(GTlabLogging-tests)
 
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
 if (NOT TARGET GTlab::Logging)
     find_package(GTlabLogging CONFIG REQUIRED)
 endif()
 
-if (NOT TARGET Qt5::Core)
-    find_package(Qt5 COMPONENTS Core Gui Widgets REQUIRED)
+if (NOT TARGET Qt5::Core AND NOT TARGET Qt6::Core)
+    include(RequireQt)
+    require_qt(COMPONENTS Core Gui Widgets)
 endif()
-
-
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 if (NOT TARGET gtest)
     include(AddGoogleTest)
@@ -40,7 +40,7 @@ add_executable(GTlabLoggingTests
 
 set_property(TARGET GTlabLoggingTests PROPERTY AUTOMOC ON)
 
-target_link_libraries(GTlabLoggingTests PRIVATE GTlab::Logging gtest Qt5::Core Qt5::Gui Qt5::Widgets)
+target_link_libraries(GTlabLoggingTests PRIVATE GTlab::Logging gtest Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Gui Qt${QT_VERSION_MAJOR}::Widgets)
 
 include(GoogleTest)
 gtest_discover_tests(GTlabLoggingTests TEST_PREFIX "Logging." DISCOVERY_MODE PRE_TEST)

--- a/tests/unittests/cmake/RequireQt.cmake
+++ b/tests/unittests/cmake/RequireQt.cmake
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025, German Aerospace Center (DLR)
+# SPDX-License-Identifier: BSD-3-Clause
+
 # ==============================================================================
 # require_qt(
 #   COMPONENTS <comp>...

--- a/tests/unittests/cmake/RequireQt.cmake
+++ b/tests/unittests/cmake/RequireQt.cmake
@@ -1,0 +1,96 @@
+# ==============================================================================
+# require_qt(
+#   COMPONENTS <comp>...
+# )
+#
+# Summary:
+#   Locate and configure a single Qt major version (5 or 6) for the entire
+#   build and ensure the requested components are available.
+#
+# Behavior:
+#   - Uses Qt’s “dual version” pattern:
+#       find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS <components>)
+#       find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS <components>)
+#
+#   - On the first call, if QT_VERSION_MAJOR is NOT defined:
+#       * If Qt has already been found by the parent project
+#         (e.g. via find_package(QT ...) or find_package(Qt6/Qt5 ...)),
+#         QT_VERSION_MAJOR is taken from the existing Qt configuration or
+#         inferred from existing Qt6::*/Qt5::* targets.
+#       * Otherwise, require_qt() calls:
+#             find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS <components>)
+#         which sets QT_VERSION_MAJOR to 5 or 6 according to what CMake
+#         finds on the search path.
+#       * QT_VERSION_MAJOR is then cached so all subsequent calls reuse
+#         the same major version.
+#
+#   - On subsequent calls (QT_VERSION_MAJOR already defined):
+#       * require_qt() simply calls:
+#             find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS <components>)
+#         to make sure the requested modules for the chosen major are available.
+#
+# Guarantees:
+#   - All callers (core and modules) in a single build tree use the same Qt
+#     major version, as determined by the first successful Qt detection.
+#   - If the requested Qt components for that major cannot be found,
+#     configuration fails with an error.
+#
+# User control of the chosen Qt version:
+#   - Standard CMake mechanisms apply. The user can steer which Qt is found by:
+#       * Adjusting CMAKE_PREFIX_PATH / Qt installation order (preferred), or
+#       * Setting Qt5_DIR / Qt6_DIR to point at a specific Qt installation
+#
+# Notes:
+#   - This function does NOT create versionless Qt:: targets. Callers are
+#     expected to link against versioned targets, e.g.:
+#         Qt${QT_VERSION_MAJOR}::Core
+#         Qt${QT_VERSION_MAJOR}::Widgets
+#         Qt${QT_VERSION_MAJOR}::<OtherComponent>
+# ==============================================================================
+function(require_qt)
+    set(options)
+    set(oneValueArgs)
+    set(multiValueArgs COMPONENTS)
+    cmake_parse_arguments(RQT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if (NOT RQT_COMPONENTS)
+        message(FATAL_ERROR "require_qt() called without COMPONENTS")
+    endif()
+    
+    # --------------------------------------------------------
+    # 1. Decide QT_VERSION_MAJOR once
+    # --------------------------------------------------------
+    if (NOT DEFINED QT_VERSION_MAJOR)
+
+        # 1a) If user hinted a specific major via Qt6_DIR / Qt5_DIR, respect that
+        if (DEFINED Qt6_DIR AND NOT DEFINED Qt5_DIR)
+            set(QT_VERSION_MAJOR 6)
+        elseif (DEFINED Qt5_DIR AND NOT DEFINED Qt6_DIR)
+            set(QT_VERSION_MAJOR 5)
+
+        elseif (DEFINED Qt5_DIR AND DEFINED Qt6_DIR)
+            set(QT_VERSION_MAJOR 6)
+        else()
+            # 1b) No specific *_DIR hints: use the standard Qt dual-version pattern
+            #     This will honor QT_DIR, CMAKE_PREFIX_PATH, etc.
+            find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS ${RQT_COMPONENTS})
+        endif()
+
+        # One-time status message
+        if (NOT DEFINED GTLAB_QT_VERSION_REPORTED AND DEFINED QT_VERSION_MAJOR)
+            message(STATUS "GTlab: using Qt${QT_VERSION_MAJOR} for this build")
+            set(GTLAB_QT_VERSION_REPORTED TRUE CACHE INTERNAL
+                "Whether the selected Qt version has been reported")
+        endif()
+    endif()
+
+    if (NOT DEFINED QT_VERSION_MAJOR)
+        message(FATAL_ERROR
+            "require_qt(): QT_VERSION_MAJOR is still undefined after detection. "
+            "Check your Qt hints: QT_DIR, Qt5_DIR, Qt6_DIR, CMAKE_PREFIX_PATH.")
+    endif()
+
+    # actually find qt
+    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS ${RQT_COMPONENTS})
+    set (QT_VERSION_MAJOR ${QT_VERSION_MAJOR} PARENT_SCOPE)
+endfunction()

--- a/tests/unittests/test_types_qt.cpp
+++ b/tests/unittests/test_types_qt.cpp
@@ -12,6 +12,7 @@
 
 #include <QWidget>
 #include <QJsonValue>
+#include <QString>
 
 // test fixture
 class TypesQt : public LogHelperTest {};
@@ -225,6 +226,9 @@ TEST_F(TypesQt, Strings)
     EXPECT_TRUE(log.contains("Test"));
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+// Qt6 does not have a QStringRef type
+
 TEST_F(TypesQt, QStringRef)
 {
     QString qstr = "MyFancyString";
@@ -233,6 +237,8 @@ TEST_F(TypesQt, QStringRef)
     gtInfo() << qstrr;
     EXPECT_TRUE(log.contains(qstr));
 }
+
+#endif
 
 TEST_F(TypesQt, StringViews)
 {

--- a/tests/unittests/test_types_qt.cpp
+++ b/tests/unittests/test_types_qt.cpp
@@ -133,7 +133,12 @@ TEST_F(TypesQt, QPair)
 {
     QPair<QString, int> pair{"test", 42};
     gtInfo() << pair;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     EXPECT_TRUE(log.contains("QPair(test,42)"));
+#else
+    // In Qt6, QPair is an alias to std::pair
+    EXPECT_TRUE(log.contains(R"(("test", 42))"));
+#endif
 }
 
 TEST_F(TypesQt, QSharedPointer)


### PR DESCRIPTION
This PR makes
 - the unit tests compile with Qt6
 - fixes Qt6 specific changes in the unit tests
 - fixes compilation of logging a std::string, if the qt_bindings are also included