### PR TITLE
Modernized ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,10 +111,8 @@ linuxBuildRelease_2.1:
   tags: ["windows", "docker"]
   extends: 
     - .run-always
-  before_script:
-    - '& $env:GTLAB_UPDATE_TOOL up --confirm-command; $null'
   script:
-    - $env:path = "$env:GTLAB_DEV_TOOLS\binDebug;$env:path"
+    - $env:PATH+=(";"+$env:QT_INSTALL_PATH+"\bin;")
     - cd build
     - .\GTlabLoggingTests.exe --gtest_output=xml:unittests.xml
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -275,7 +275,7 @@ conan-pkg 2/2:
 # code quality
 cppcheck:
   stage: codequality
-  extends: .cppCheckReportTemplate
+  extends: .cppCheckTemplate
   allow_failure: true
 
 check-license:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -309,3 +309,4 @@ badgesUnstable:
     - linuxBuildDebug_2.1
     - testWin_2.0
     - testLinux_2.0
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,40 +20,16 @@ include:
 stages:
   - update
   - build
-  - buildStatic
   - test
   - regressionTest
-  - unstableBuild
-  - unstableTest
   - deploy
   - codequality
   - package
   - badges
 
 # build on Windows system
-windowsBuildDebug:
+windowsBuildDebug_2.0:
   stage: build
-  extends: 
-    - .build-win_17
-    - .run-always
-  script:
-    - $env:PATH+=(";"+$env:QT_INSTALL_PATH+"\bin;")
-    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install-msvc2017-dbg -DBUILD_UNITTESTS=ON
-    - cmake --build build --target install
-
-windowsBuildStaticDebug:
-  stage: buildStatic
-  extends: 
-    - .build-win_17
-    - .run-master-and-tags
-  script:
-    - $env:PATH+=(";"+$env:QT_INSTALL_PATH+"\bin;")
-    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install-msvc2017-static-dbg -DBUILD_UNITTESTS=ON -DBUILD_SHARED_LIBS=OFF
-    - cmake --build build --target install
-    
-    
-windowsBuildDebugUnstable:
-  stage: unstableBuild
   extends: 
     - .build-win_20
     - .run-always
@@ -62,28 +38,18 @@ windowsBuildDebugUnstable:
     - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install-msvc2019-dbg -DBUILD_UNITTESTS=ON
     - cmake --build build --target install
 
-windowsBuildRelease:
+windowsBuildDebug_2.1:
   stage: build
   extends: 
-    - .build-win_17
-    - .run-master-and-tags
+    - .build-win_21
+    - .run-always
   script:
     - $env:PATH+=(";"+$env:QT_INSTALL_PATH+"\bin;")
-    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install-msvc2017
+    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install-msvc2026-dbg -DBUILD_UNITTESTS=ON
     - cmake --build build --target install
 
-windowsBuildStaticRelease:
-  stage: buildStatic
-  extends: 
-    - .build-win_17
-    - .run-master-and-tags
-  script:
-    - $env:PATH+=(";"+$env:QT_INSTALL_PATH+"\bin;")
-    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install-msvc2017-static -DBUILD_SHARED_LIBS=OFF
-    - cmake --build build --target install
-
-windowsBuildReleaseUnstable:
-  stage: unstableBuild
+windowsBuildRelease_2.0:
+  stage: build
   extends: 
     - .build-win_20
     - .run-master-and-tags
@@ -92,27 +58,19 @@ windowsBuildReleaseUnstable:
     - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install-msvc2019
     - cmake --build build --target install
 
-# build on Linux system
-linuxBuildDebug:
+windowsBuildRelease_2.1:
   stage: build
   extends: 
-    - .build-linux_17
-    - .run-always
-  script:
-    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install-linux-dbg -DBUILD_UNITTESTS=ON
-    - cmake --build build --target install
-
-linuxBuildStaticDebug:
-  stage: buildStatic
-  extends: 
-    - .build-linux_17
+    - .build-win_21
     - .run-master-and-tags
   script:
-    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install-linux-static-dbg -DBUILD_UNITTESTS=ON -DBUILD_SHARED_LIBS=OFF
+    - $env:PATH+=(";"+$env:QT_INSTALL_PATH+"\bin;")
+    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install-msvc2026
     - cmake --build build --target install
-    
-linuxBuildDebugUnstable:
-  stage: unstableBuild
+
+# build on Linux system   
+linuxBuildDebug_2.0:
+  stage: build
   extends: 
     - .build-linux_20
     - .run-always
@@ -120,28 +78,28 @@ linuxBuildDebugUnstable:
     - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install-linux-dbg -DBUILD_UNITTESTS=ON
     - cmake --build build --target install
 
-linuxBuildRelease:
+linuxBuildDebug_2.1:
   stage: build
   extends: 
-    - .build-linux_17
+    - .build-linux_21
+    - .run-always
+  script:
+    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install-linux-dbg -DBUILD_UNITTESTS=ON
+    - cmake --build build --target install
+ 
+linuxBuildRelease_2.0:
+  stage: build
+  extends: 
+    - .build-linux_20
     - .run-master-and-tags
   script:
     - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install-linux
     - cmake --build build --target install
 
-linuxBuildStaticRelease:
-  stage: buildStatic
+linuxBuildRelease_2.1:
+  stage: build
   extends: 
-    - .build-linux_17
-    - .run-master-and-tags
-  script:
-    - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install-linux-static -DBUILD_SHARED_LIBS=OFF
-    - cmake --build build --target install
- 
-linuxBuildReleaseUnstable:
-  stage: unstableBuild
-  extends: 
-    - .build-linux_20
+    - .build-linux_21
     - .run-master-and-tags
   script:
     - cmake -B build -S . -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install-linux
@@ -167,19 +125,19 @@ linuxBuildReleaseUnstable:
       junit: build/unittests.xml
 
 # run tests using the binary built before
-testWin:
+testWin_2.0:
   stage: test
-  image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/gtlabdev-1_7-win
-  extends: 
-    - .testWinTemplate
-  needs: ["windowsBuildDebug"]
-
-testWinUnstable:
-  stage: unstableTest
-  image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/gtlabdev-2_0-win
   extends:
     - .testWinTemplate
-  needs: ["windowsBuildDebugUnstable"]
+    - .windocker_2.0
+  needs: ["windowsBuildDebug_2.0"]
+
+testWin_2.1:
+  stage: test
+  extends:
+    - .testWinTemplate
+    - .windocker_2.1
+  needs: ["windowsBuildDebug_2.1"]
 
 .testLinuxTemplate:
   tags: ["linux", "docker"]
@@ -200,19 +158,19 @@ testWinUnstable:
     reports:
       junit: unittests.xml
 
-testLinux:
+testLinux_2.0:
   stage: test
   extends: 
     - .testLinuxTemplate
-  image: at-twk-hal9000.intra.dlr.de:5000/dlr-at/gtlabdev-1_7-buster
-  needs: ["linuxBuildDebug"]
+    - .linuxdocker_2.0
+  needs: ["linuxBuildDebug_2.0"]
 
-testLinuxUnstable:
-  stage: unstableTest
+testLinux_2.1:
+  stage: test
   extends: 
     - .testLinuxTemplate
-    - .linuxdocker
-  needs: ["linuxBuildDebugUnstable"]
+    - .linuxdocker_2.1
+  needs: ["linuxBuildDebug_2.1"]
 
 .package:
   stage: package
@@ -232,25 +190,25 @@ testLinuxUnstable:
 
 package-win-gtlab_2.0:
   extends: [".package"]
-  needs: ["windowsBuildDebugUnstable", "windowsBuildReleaseUnstable"]
+  needs: ["windowsBuildDebug_2.0", "windowsBuildRelease_2.0"]
   variables:
     toolchain: msvc2019
 
-package-win-gtlab_1.7:
+package-win-gtlab_2.1:
   extends: [".package"]
-  needs: ["windowsBuildDebug", "windowsBuildRelease"]
+  needs: ["windowsBuildDebug_2.1", "windowsBuildRelease_2.1"]
   variables:
-    toolchain: msvc2017
+    toolchain: msvc2026
 
 package-linux-gtlab_2.0:
   extends: [".package"]
-  needs: ["linuxBuildDebugUnstable", "linuxBuildReleaseUnstable"]
+  needs: ["linuxBuildDebug_2.0", "linuxBuildRelease_2.0"]
   variables:
     toolchain: linux
 
-package-linux-gtlab_1.7:
+package-linux-gtlab_2.1:
   extends: [".package"]
-  needs: ["linuxBuildDebug", "linuxBuildRelease"]
+  needs: ["linuxBuildDebug_2.1", "linuxBuildRelease_2.1"]
   variables:
     toolchain: linux
 
@@ -269,18 +227,6 @@ package-linux-gtlab_1.7:
   variables:
     toolchain: msvc2017
     GIT_STRATEGY: "none"
-
-package-win-gtlab_1.7_static:
-  extends: [".package-static"]
-  needs: ["windowsBuildStaticDebug", "windowsBuildStaticRelease"]
-  variables:
-    toolchain: msvc2017
-
-package-linux-gtlab_1.7_static:
-  extends: [".package-static"]
-  needs: ["linuxBuildStaticDebug", "linuxBuildStaticRelease"]
-  variables:
-    toolchain: linux
 
 .conan:
   stage: package
@@ -351,24 +297,15 @@ pages:
   extends: .pageTemplate
 
 # badges
-badges:
+badgesUnstable:
   stage: badges
   extends: 
     - .stable-only-master
     - .badgeTemplate
   dependencies:
-    - windowsBuildDebug
-    - linuxBuildDebug
-    - testWin
-    - testLinux
-
-badgesUnstable:
-  stage: badges
-  extends: 
-    - .unstable-only-master
-    - .badgeTemplate
-  dependencies:
-    - windowsBuildDebugUnstable
-    - linuxBuildDebugUnstable
-    - testWinUnstable
-    - testLinuxUnstable
+    - windowsBuildDebug_2.0
+    - linuxBuildDebug_2.0
+    - windowsBuildDebug_2.1
+    - linuxBuildDebug_2.1
+    - testWin_2.0
+    - testLinux_2.0


### PR DESCRIPTION
Remove 1.7 jobs
Added 2.1 jobs

## Summary by Sourcery

Update GitLab CI to focus on 2.0 and 2.1 pipelines and remove legacy 1.7 and static/unstable jobs.

CI:
- Rename Windows and Linux build and test jobs to versioned 2.0/2.1 variants and update their templates and dependencies.
- Remove buildStatic and unstable stages and associated static and unstable build/test jobs from the pipeline.
- Adjust packaging jobs to consume the new 2.0/2.1 build outputs and reflect updated toolchains.
- Simplify badge generation to depend on the new 2.0/2.1 build and test jobs instead of legacy pipelines.