### PR TITLE
Use standardized library path "lib"

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -47,7 +47,7 @@ class GTlabLoggingConan(ConanFile):
         
         self.cpp_info.includedirs.append(os.path.join("include", "logging"))
 
-        self.cpp_info.libdirs = ['lib', 'lib/logging']
+        self.cpp_info.libdirs = ['lib']
 
         if self.settings.build_type != "Debug":
             self.cpp_info.libs = ['GTlabLogging']

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023, German Aerospace Center (DLR)
 # SPDX-License-Identifier: BSD-3-Clause
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15)
 project(GTlabLogging VERSION 4.4.2)
 
 if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
@@ -73,8 +73,8 @@ set_target_properties(GTlabLogging PROPERTIES
 install (TARGETS GTlabLogging
          EXPORT GTlabLoggingTargets
          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/logging
-         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/logging
+         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 # install include files

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023, German Aerospace Center (DLR)
 # SPDX-License-Identifier: BSD-3-Clause
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(GTlabLogging-tests)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)

--- a/tests/unittests/cmake/AddGoogleTest.cmake
+++ b/tests/unittests/cmake/AddGoogleTest.cmake
@@ -10,20 +10,15 @@
 #
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-# Build gtest as a static lib
+# Build gtest as a static library
 set(BUILD_SHARED_LIBS OFF)
 
 include(FetchContent)
 FetchContent_Declare(googletest
-	GIT_REPOSITORY      https://github.com/google/googletest.git
-	GIT_TAG             release-1.12.1)
-FetchContent_GetProperties(googletest)
-if(NOT googletest_POPULATED)
-	FetchContent_Populate(googletest)
-	set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE BOOL "")
-	add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
-	unset(CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
-endif()
+    GIT_REPOSITORY      https://github.com/google/googletest.git
+    GIT_TAG             v1.15.2
+    EXCLUDE_FROM_ALL)
+FetchContent_MakeAvailable(googletest)
 
 
 if(CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
Also minor cmake modernization

## Summary by Sourcery

Standardize the library installation layout and modernize CMake configuration across the main project and unit tests.

Enhancements:
- Update CMake minimum required version to 3.15 for the main project and unit tests.
- Modernize googletest integration using FetchContent_MakeAvailable and a newer googletest release.

Build:
- Install GTlabLogging libraries directly into the standard ${CMAKE_INSTALL_LIBDIR} instead of a nested logging subdirectory.
- Align Conan package library directories to use only the standard "lib" path.

Tests:
- Refresh unit test CMake setup to use the newer CMake minimum and updated googletest configuration.